### PR TITLE
NGINX pass to backend port 3000 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This image built based on [theasp/novnc](https://github.com/theasp/docker-novnc/
 
         http://localhost:3000/path/to/mock
 
+    By default, if port not specified in path it will be redirected to port 3000. Request to `http://localhost/path/to/mock` is equal to `http://localhost/3000/path/to/mock`.
+
 ## 📔 Usage
 
 You can try this image with Docker Compose by simply checking it out and running `docker compose up --build`. For more details, please check `docker-compose.yaml` file.

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -11,5 +11,9 @@ http {
             rewrite "^/\d{4}(?:/(.*))?" /$1 break;
             proxy_pass http://127.0.0.1:$port;
         }
+
+        location ~ / {
+            proxy_pass http://127.0.0.1:3000;
+        }
     }
 }


### PR DESCRIPTION
If no port in path specified, pass it to backend port 3000 by default.