### PR TITLE
Restrict NGINX path port range to 3000-3999

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This image built based on [theasp/novnc](https://github.com/theasp/docker-novnc/
 
         http://localhost:3000/path/to/mock
 
+    > Only port range in 3000-3999 will be forwarded by configuration, otherwise NGINX will respond with **404 Not Found**.
+
 ## 📔 Usage
 
 You can try this image with Docker Compose by simply checking it out and running `docker compose up --build`. For more details, please check `docker-compose.yaml` file.

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -7,7 +7,7 @@ http {
     server {
         listen 0.0.0.0:80;
 
-        location ~ ^/(?<port>[0-9]+)(?:/|$) {
+        location ~ "^/(?<port>3\d{3})(?:/|$)" {
             rewrite "^/\d{4}(?:/(.*))?" /$1 break;
             proxy_pass http://127.0.0.1:$port;
         }


### PR DESCRIPTION
Restrict path port forwarding range to 3000 ~ 3999.