### PR TITLE
Cleanup APT cache after installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y \
     x11vnc \
     xdg-utils \
     xvfb \
-    && apt-get clean
+    && rm -rf /var/lib/apt/lists/*
 
 COPY .mockoon-version ./
 RUN MOCKOON_VERSION="$(cat .mockoon-version)" \


### PR DESCRIPTION
Slight reduction in image size (~10MB).